### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/buszuj/267d3540-9623-4907-ba71-a15cc54b0903/8cd468a6-b153-41a9-9873-d6fab726cdd7/_apis/work/boardbadge/a8535559-6202-4a0c-bcd5-3d1bdd6a8a13)](https://dev.azure.com/buszuj/267d3540-9623-4907-ba71-a15cc54b0903/_boards/board/t/8cd468a6-b153-41a9-9873-d6fab726cdd7/Microsoft.RequirementCategory)
 # hello-world2
 this Repo is for Github Docs practice
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/buszuj/267d3540-9623-4907-ba71-a15cc54b0903/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.